### PR TITLE
Point GitHub link to edu page

### DIFF
--- a/_data/sponsors.yaml
+++ b/_data/sponsors.yaml
@@ -36,4 +36,4 @@
 - name: GitHub
   tier: bronze
   image-url: /assets/images/sponsors/github.png
-  url: https://github.com/
+  url: https://education.github.com/


### PR DESCRIPTION
Just adjusted the sponsor link to point to education.github.com