### PR TITLE
Made beacon.io bigger

### DIFF
--- a/_data/sponsors.yaml
+++ b/_data/sponsors.yaml
@@ -50,5 +50,5 @@
 
 - name: Beacon.io
   tier: startup
-  image-url: /assets/images/sponsors/beaconio.png
+  image-url: /assets/images/sponsors/beaconio.jpg
   url: https://www.beacon.io/


### PR DESCRIPTION
## Makes the Beacon.io logo bigger

The business school asked for this. Leaving it at the bottom but making it larger on screen. Thoughts? Can also tell them that it need to stay small. 

The logo itself is a higher res one they got from the company, so we should keep that. 

## Some questions
<!-- You can leave this and check them once the PR has been created. -->

- [x] I have read the contributing guidelines
- [x] I abide by this repository Code of Conduct

